### PR TITLE
chore: various embedding fixes

### DIFF
--- a/field_test.go
+++ b/field_test.go
@@ -55,8 +55,8 @@ func TestEncodeNested(t *testing.T) {
 
 //nolint:govet
 type StructWithEmbed struct {
-	A            int32 `protobuf:"1"`
-	*EmbedStruct `protobuf:"2"`
+	A int32 `protobuf:"1"`
+	*EmbedStruct
 }
 
 type EmbedStruct struct {

--- a/marshal.go
+++ b/marshal.go
@@ -115,11 +115,23 @@ func (m *marshaller) encodeFields(val reflect.Value, fieldsData []FieldData) {
 // fieldByIndex returns the field of the struct by its index if the field is exported.
 // Otherwise, it returns empty reflect.Value.
 func fieldByIndex(structVal reflect.Value, data FieldData) reflect.Value {
-	if data.Field.IsExported() && structVal.IsValid() {
-		return structVal.FieldByIndex(data.FieldIndex)
+	if !structVal.IsValid() || !data.Field.IsExported() || len(data.FieldIndex) == 0 {
+		return reflect.Value{}
 	}
 
-	return reflect.Value{}
+	var result reflect.Value
+
+	for i := 0; i < len(data.FieldIndex); i++ {
+		index := data.FieldIndex[:i+1]
+
+		result = structVal.FieldByIndex(index)
+		if len(data.FieldIndex) > 1 && result.Kind() == reflect.Ptr && result.IsNil() {
+			// Embedded field is nil, return empty reflect.Value. Avo
+			return reflect.Value{}
+		}
+	}
+
+	return result
 }
 
 //nolint:cyclop


### PR DESCRIPTION
This PR does several things:
- Nil pointer embedded structs are now handled correctly.
- Embedded structs no longer need to have `protobuf:<n>` tags since they didn't use them to begin with.
- Embedding primitive types now reports an error instead of silently breaking.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>