### PR TITLE
feat: implement custom encoders/decoders

### DIFF
--- a/pointer.go
+++ b/pointer.go
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package protoenc
+
+//TODO: remove this once Go 1.19 lands
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+// A Pointer is an atomic pointer of type *T. The zero value is a nil *T.
+type Pointer[T any] struct {
+	v unsafe.Pointer
+}
+
+// Load atomically loads and returns the value stored in x.
+func (x *Pointer[T]) Load() *T { return (*T)(atomic.LoadPointer(&x.v)) }
+
+// CompareAndSwap executes the compare-and-swap operation for x.
+func (x *Pointer[T]) CompareAndSwap(old, new *T) (swapped bool) {
+	return atomic.CompareAndSwapPointer(&x.v, unsafe.Pointer(old), unsafe.Pointer(new))
+}


### PR DESCRIPTION
This PR adds the ability to use free functions as custom encoders/decoders. This is important because we want to implement encoding for foreign types (for example netip.*).

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>