### PR TITLE
fix: add missing test and proper check for `map[string]interface{}`

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -51,8 +51,8 @@ func BenchmarkCustom(b *testing.B) {
 		protoenc.CleanEncoderDecoder()
 	})
 
-	o := OneFieldStruct[CustomEncoderStruct]{
-		Field: CustomEncoderStruct{
+	o := Value[CustomEncoderStruct]{
+		V: CustomEncoderStruct{
 			Value: 150,
 		},
 	}
@@ -65,9 +65,9 @@ func BenchmarkCustom(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	target := &OneFieldStruct[CustomEncoderStruct]{}
+	target := &Value[CustomEncoderStruct]{}
 	for i := 0; i < b.N; i++ {
-		*target = OneFieldStruct[CustomEncoderStruct]{}
+		*target = Value[CustomEncoderStruct]{}
 
 		err := protoenc.Unmarshal(encoded, target)
 		if err != nil {
@@ -75,7 +75,7 @@ func BenchmarkCustom(b *testing.B) {
 		}
 	}
 
-	require.Equal(b, o.Field.Value+2, target.Field.Value)
+	require.Equal(b, o.V.Value+2, target.V.Value)
 }
 
 func BenchmarkSlice(b *testing.B) {

--- a/slice_test.go
+++ b/slice_test.go
@@ -271,12 +271,12 @@ func testEncodeDecodeWrapped[T any](slc T, expected []byte) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
-		original := OneFieldStruct[T]{Field: slc}
+		original := Value[T]{V: slc}
 		buf := must(protoenc.Marshal(&original))(t)
 
 		require.Equal(t, expected, buf)
 
-		var decoded OneFieldStruct[T]
+		var decoded Value[T]
 
 		require.NoError(t, protoenc.Unmarshal(buf, &decoded))
 		require.Equal(t, original, decoded)
@@ -340,6 +340,9 @@ func TestDisallowedTypes(t *testing.T) {
 		},
 		"map[string]string": {
 			fn: testDisallowedTypes[map[string]string],
+		},
+		"[]map[string]string": {
+			fn: testDisallowedTypes[[]map[string]string],
 		},
 		"sliceWrapper[*int]": {
 			fn: testDisallowedTypes[sliceWrapper[*int]],

--- a/type_cache.go
+++ b/type_cache.go
@@ -451,6 +451,10 @@ func validateFieldPtr(typ reflect.Type) error {
 }
 
 func validateMap(elem reflect.Type) error {
+	if elem == typeMapInterface {
+		return nil
+	}
+
 	if err := validateMapKey(elem.Key()); err != nil {
 		return err
 	}


### PR DESCRIPTION
Somehow this got lost during transition to new type checking. This commit should fix that.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>