### PR TITLE
fix: encode (u)int(16|8)s as varints

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -151,12 +151,12 @@ func (m *marshaller) encodeValue(num protowire.Number, val reflect.Value) {
 		putBool(m, val.Bool())
 
 	case reflect.Int8, reflect.Int16:
-		putTag(m, num, protowire.Fixed32Type)
-		putInt32(m, int32(val.Int()))
+		putTag(m, num, protowire.VarintType)
+		putUVarint(m, val.Int())
 
 	case reflect.Uint8, reflect.Uint16:
-		putTag(m, num, protowire.Fixed32Type)
-		putInt32(m, int32(val.Uint()))
+		putTag(m, num, protowire.VarintType)
+		putUVarint(m, val.Uint())
 
 	case reflect.Int, reflect.Int32, reflect.Int64:
 		putTag(m, num, protowire.VarintType)
@@ -399,12 +399,12 @@ func (m *marshaller) sliceReflect(key protowire.Number, val reflect.Value) {
 	switch elem.Kind() { //nolint:exhaustive
 	case reflect.Int8, reflect.Int16:
 		for i := 0; i < sliceLen; i++ {
-			putInt32(&result, int32(val.Index(i).Int()))
+			putUVarint(&result, val.Index(i).Int())
 		}
 
 	case reflect.Uint8, reflect.Uint16:
 		for i := 0; i < sliceLen; i++ {
-			putInt32(&result, uint32(val.Index(i).Uint()))
+			putUVarint(&result, val.Index(i).Uint())
 		}
 
 	case reflect.Bool:

--- a/scanner.go
+++ b/scanner.go
@@ -300,7 +300,7 @@ func (s *dataScanner) Wiretype() protowire.Type {
 func getDataScannerFor(eltype reflect.Type, buf []byte) (dataScanner, bool, error) {
 	switch eltype.Kind() { //nolint:exhaustive
 	case reflect.Uint8, reflect.Uint16, reflect.Int8, reflect.Int16:
-		return makeDataScanner(protowire.Fixed32Type, buf), true, nil
+		return makeDataScanner(protowire.VarintType, buf), true, nil
 
 	case reflect.Bool, reflect.Int32, reflect.Int64, reflect.Int,
 		reflect.Uint32, reflect.Uint64, reflect.Uint:

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -439,6 +439,7 @@ func unmarshalByteSeqeunce(dst reflect.Value, val complexValue) error {
 }
 
 func slice(dst reflect.Value, val complexValue) error {
+	// TODO: this code doesn't support the case when slice is encoded in several chunks across the message
 	elemType := dst.Type().Elem()
 
 	// we only decode bytes as []byte or [n]byte field


### PR DESCRIPTION
This commit changes encoding of smaller ints to varint scheme. It should make our enum types compatible with proto enum types.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>